### PR TITLE
Add related links to about page with EN translation

### DIFF
--- a/tmpl/web/en/inc/layout-v2.html
+++ b/tmpl/web/en/inc/layout-v2.html
@@ -1,0 +1,24 @@
+<!DOCTYPE html>
+<html lang="en">
+<head>
+    <meta charset="UTF-8">
+    <meta name="viewport" content="width=device-width, initial-scale=1.0">
+    <title>{% block title %}My Site{% endblock %}</title>
+    <link rel="stylesheet" href="/css/style.css">
+    {# --- SEO Canonical & Alternate URLs --- #}
+    {% if canonicalUrl %}
+        <link rel="canonical" href="{{ canonicalUrl }}">
+    {% endif %}
+    {% if alternateUrls %}
+        {% for lang, url in alternateUrls %}
+            <link rel="alternate" hreflang="{{ lang }}" href="{{ url }}">
+        {% endfor %}
+    {% endif %}
+</head>
+<body>
+{% include "inc/nav-v2.html" %}
+<main>
+    {% block content %}{% endblock %}
+</main>
+</body>
+</html>

--- a/tmpl/web/en/inc/nav-v2.html
+++ b/tmpl/web/en/inc/nav-v2.html
@@ -1,0 +1,91 @@
+<nav>
+    <ul class="main-menu" id="mainMenu">
+        <li class="home-link">
+            <a href="/{{ locale }}/v2/">
+                <img src="/favicon.ico" alt="Home" class="home-icon">
+                <span class="home-text">Home</span>
+            </a>
+        </li>
+        <li><a href="/{{ locale }}/v2/about.html">About</a></li>
+        <li><a href="/{{ locale }}/v2/features.html">Features</a></li>
+        <li>
+            <span>Examples</span>
+            <ul>
+                <li><a href="/{{ locale }}/v2/examples/landing.html">Landing</a></li>
+                <li><a href="/{{ locale }}/v2/examples/blog.html">Blog</a></li>
+                <li><a href="/{{ locale }}/v2/examples/hybrid.html">Hybrid</a></li>
+            </ul>
+        </li>
+        <li>
+            <span>Documentation</span>
+            <ul>
+                <li><a href="/{{ locale }}/v2/docs/overview.html">Overview</a></li>
+                <li><a href="/{{ locale }}/v2/docs/install.html">Installation</a></li>
+                <li><a href="/{{ locale }}/v2/docs/config.html">Configuration</a></li>
+                <li><a href="/{{ locale }}/v2/docs/locales.html">Locales</a></li>
+                <li><a href="/{{ locale }}/v2/docs/translate.html">Translations</a></li>
+                <li><a href="/{{ locale }}/v2/docs/cli.html">CLI</a></li>
+                <li><a href="/{{ locale }}/v2/docs/dev-llm.html">LLM Development</a></li>
+                <li><a href="/{{ locale }}/v2/docs/faq.html">FAQ</a></li>
+                <li><a href="/{{ locale }}/v2/docs/plugins.html">Plugins</a></li>
+                <li><a href="/{{ locale }}/v2/docs/troubleshooting.html">Troubleshooting</a></li>
+            </ul>
+        </li>
+        <li><a href="/{{ locale }}/v2/roadmap.html">Roadmap</a></li>
+    </ul>
+
+    <div class="nav-right">
+        <div class="locale-switcher-inline">
+            {% for loc in allowedLocales %}
+            {% if not loop.first %}|{% endif %}
+            {% if loc == locale %}
+            <span>{{ loc | upper }}</span>
+            {% else %}
+            <a href="/{{ loc }}" onclick="return switchLocale('{{ loc }}')">{{ loc | upper }}</a>
+            {% endif %}
+            {% endfor %}
+        </div>
+        <button class="menu-toggle" onclick="toggleMenu()">☰</button>
+    </div>
+</nav>
+
+<script>
+    function toggleMenu() {
+        const menu = document.getElementById('mainMenu');
+        const navRight = document.querySelector('.nav-right');
+        if (menu) menu.classList.toggle('open');
+        if (navRight) navRight.classList.toggle('hidden-on-open');
+    }
+
+    // @formatter:off
+    function switchLocale(targetLocale) {
+        const allowed = {{ allowedLocales | dump | safe }};
+        const path = window.location.pathname;
+        const current = allowed.find(loc => path === `/${loc}` || path.startsWith(`/${loc}/`));
+        let basePath = path;
+
+        if (current) {
+            basePath = path.replace(new RegExp(`^/${current}`), '');
+        }
+        window.location.href = `/${targetLocale}${basePath || '/'}`;
+        return false;
+    }
+    // @formatter:on
+
+    document.addEventListener('DOMContentLoaded', () => {
+        if (window.innerWidth <= 768) {
+            const toggles = document.querySelectorAll('.main-menu > li > span');
+            toggles.forEach(span => {
+                span.addEventListener('click', () => {
+                    const parent = span.parentElement;
+                    parent.classList.toggle('open');
+                    const submenu = span.nextElementSibling;
+                    if (submenu) {
+                        const expanded = submenu.style.maxHeight;
+                        submenu.style.maxHeight = expanded ? null : submenu.scrollHeight + 'px';
+                    }
+                });
+            });
+        }
+    });
+</script>

--- a/tmpl/web/en/v2/about.html
+++ b/tmpl/web/en/v2/about.html
@@ -1,0 +1,58 @@
+{% extends "inc/layout-v2.html" %}
+
+{% block title %}About the Project — TeqCMS v2{% endblock %}
+
+{% block content %}
+<h1>A site built by an AI agent</h1>
+<!-- AGENT: page regenerated following ctx instructions -->
+<p>This site was generated entirely in a dialogue with an LLM agent. We set a task, and the agent produces templates, texts, and translations that go straight into the repository.</p>
+
+<h2>Why it works</h2>
+<ul>
+    <li>TeqCMS has no database: every page is just a file.</li>
+    <li>There is no admin panel, so content is edited directly.</li>
+    <li>Any tool, including an LLM, can work with these files without restrictions.</li>
+</ul>
+
+<h2>Content as code</h2>
+<ul>
+    <li>Pages and translations live side by side and are versioned through git.</li>
+    <li>The HTML structure is readable and suitable for generation.</li>
+    <li>Every edit is tracked in commit history.</li>
+</ul>
+
+<h2>LLM in the creation process</h2>
+<ul>
+    <li>The agent is not embedded into the CMS — it simply writes files.</li>
+    <li>New pages and sections appear as a result of dialogue, not manual labor.</li>
+    <li>The CMS shows exactly what the agent generated, without extra layers.</li>
+</ul>
+
+<h2>What the CMS does</h2>
+<ul>
+    <li>Renders pages on the server with Nunjucks.</li>
+    <li>Detects locale from the URL and loads the proper templates.</li>
+    <li>Does not manage content — it merely displays it.</li>
+</ul>
+
+<h2>Who it's for</h2>
+<ul>
+    <li>Developers working with LLMs and generative tools.</li>
+    <li>Teams that prefer a "content as code" approach.</li>
+    <li>Those who want to use AI not as a plugin but as a full participant in the process.</li>
+</ul>
+
+<h2>Give it a try</h2>
+<ul>
+    <li>Check out the source code on GitHub and explore the file structure.</li>
+    <li>Formulate a task for the agent and add your own page.</li>
+</ul>
+
+<h2>Related resources</h2>
+<ul>
+    <li><a href="https://github.com/flancer32/teq-cms">TeqCMS on GitHub</a></li>
+    <li><a href="https://www.npmjs.com/package/@flancer32/teq-cms">TeqCMS on npm</a></li>
+    <li><a href="https://github.com/flancer32/teq-cms-promo">TeqCMS Promo on GitHub</a></li>
+    <li><a href="https://wiredgeese.com">Author's site</a></li>
+</ul>
+{% endblock %}

--- a/tmpl/web/ru/v2/about.html
+++ b/tmpl/web/ru/v2/about.html
@@ -47,4 +47,12 @@
     <li>Откройте исходники на GitHub и посмотрите структуру файлов.</li>
     <li>Сформулируйте задачу агенту и добавьте свою страницу.</li>
 </ul>
+
+<h2>Связанные ресурсы</h2>
+<ul>
+    <li><a href="https://github.com/flancer32/teq-cms">TeqCMS на GitHub</a></li>
+    <li><a href="https://www.npmjs.com/package/@flancer32/teq-cms">TeqCMS на npm</a></li>
+    <li><a href="https://github.com/flancer32/teq-cms-promo">TeqCMS Promo на GitHub</a></li>
+    <li><a href="https://wiredgeese.com">Сайт автора</a></li>
+</ul>
 {% endblock %}


### PR DESCRIPTION
## Summary
- link to resources from globals on RU about page
- create v2 layout and navigation for English locale
- translate RU about page into English

## Testing
- `npm test` *(fails: Missing script `test`)*

------
https://chatgpt.com/codex/tasks/task_e_6879130e3ac4832da000475a6d5a6bbb